### PR TITLE
chore(vite): allow Render preview host and bind to all interfaces

### DIFF
--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -7,7 +7,8 @@ export default defineConfig({
   plugins: [react(), tailwindcss()],
   server: {
     host: '0.0.0.0', // expose to network
-    port: Number(process.env.PORT) || 4173, // Render will provide PORT
+    port: Number(process.env.PORT) || 4173, 
+    allowedHosts: ['realtime-frontend-boop.onrender.com'] 
   },
   preview: {
     host: '0.0.0.0',


### PR DESCRIPTION
- Added  to vite.config.ts so server binds to all interfaces
- Added  entry for realtime-frontend-boop.onrender.com to allow Render previews