### PR TITLE
Add root HTTP GET route to backend to fix "Cannot GET /" on Render

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -7,6 +7,10 @@ const app = express()
 const PORT = process.env.PORT ? Number(process.env.PORT) : 3000
 const HOST = process.env.HOST || '0.0.0.0' // Bind to 0.0.0.0 on Render
 
+app.get('/', (req, res) => {
+  res.send('Backend is running 🚀')
+})
+
 // Endpoint list
 const endpoints = [
   {


### PR DESCRIPTION
- Adds a simple '/' GET route returning a health check message
- Keeps WebSocket and polling logic intact
- Ensures backend responds to HTTP requests on Render